### PR TITLE
cssselect as standalone module

### DIFF
--- a/pdfquery/pdfquery.py
+++ b/pdfquery/pdfquery.py
@@ -8,7 +8,8 @@ from pdfminer.converter import PDFPageAggregator
 from pdfminer.pdftypes import resolve1
 
 from pyquery import PyQuery
-from lxml import cssselect, etree
+from lxml import etree
+import cssselect
 
 # custom selectors monkey-patch
 
@@ -20,7 +21,7 @@ def _xpath_in_bbox(self, xpath, expr):
     xpath.add_post_condition("@x1 <= %s" % x1)
     xpath.add_post_condition("@y1 <= %s" % y1)
     return xpath
-cssselect.Function._xpath_in_bbox = _xpath_in_bbox
+cssselect.parser.Function._xpath_in_bbox = _xpath_in_bbox
 
 def _xpath_overlaps_bbox(self, xpath, expr):
     x0,y0,x1,y1 = map(float, expr.split(","))


### PR DESCRIPTION
Since lxml 3.0 cssselect is an independent project. I had some problems getting pdfquery to work, as the Function object is not available directly in the cssselect module, but in cssselect.parser.
