### PR TITLE
fix for reading text from nodes that are corrupted

### DIFF
--- a/pdfquery/pdfquery.py
+++ b/pdfquery/pdfquery.py
@@ -532,7 +532,10 @@ class PDFQuery(object):
 
         # add text
         if hasattr(node, 'get_text'):
-            branch.text = node.get_text()
+            try:
+                branch.text = node.get_text()
+            except ValueError:
+                branch.text = ''
 
         # add children if node is an iterable
         if hasattr(node, '__iter__'):
@@ -546,7 +549,7 @@ class PDFQuery(object):
                         last.text += child.text
                         last.set(
                             '_obj_id',
-                            last.get('_obj_id') + "," + child.get('_obj_id')
+                            last.get('_obj_id', '') + "," + child.get('_obj_id', '')
                         )
                         continue
                 # sort children by bounding boxes


### PR DESCRIPTION
As described in the issue https://github.com/jcushman/pdfquery/issues/39 some nodes that have corrupted unicode, breakspace etc. raise ValueError when they can most likely be interpreted as empty.

This change would interpret `ValueErrors` on `node.get_text()` as an empty text.