### PR TITLE
Added laparams parameter to PDFQuery class

### DIFF
--- a/pdfquery/pdfquery.py
+++ b/pdfquery/pdfquery.py
@@ -302,6 +302,7 @@ class PDFQuery(object):
             normalize_spaces=True,
             resort=True,
             parse_tree_cacher=None,
+            laparams=None,
     ):
         # store input
         self.merge_tags = merge_tags
@@ -353,7 +354,8 @@ class PDFQuery(object):
 
         # set up layout parsing
         rsrcmgr = PDFResourceManager()
-        laparams = LAParams(all_texts=True, detect_vertical=True)
+        if laparams is not None:
+            laparams = LAParams(all_texts=True, detect_vertical=True)
         self.device = PDFPageAggregator(rsrcmgr, laparams=laparams)
         self.interpreter = PDFPageInterpreter(rsrcmgr, self.device)
 


### PR DESCRIPTION
I stumbled over some problems with extremly narrow spaces in some pdf file. So I needed to take control over the PDFMiner parameters. 

I suggest to include those as a parameter to PDFQuery class.

Thanks!
Stefan Winkler