### PR TITLE
Fix TypeError w/r to bytestring on Py3

### DIFF
--- a/pdfquery/pdfquery.py
+++ b/pdfquery/pdfquery.py
@@ -268,7 +268,7 @@ class QPDFDocument(PDFDocument):
 
         # handle string prefix
         if 'P' in label_format:
-            page_label = label_format['P']+page_label
+            page_label = smart_unicode_decode(label_format['P']) + page_label
 
         return page_label
 


### PR DESCRIPTION
A PDF couldn't be loaded with PDFQuery on Python 3.5 because of a TypeError.
`label_format['P']` appeared to be a bytestring, which clashes with the unicode string `page_label`.

This patch ensures that only unicode strings are returned.

Unfortunately, I cannot attach the PDF that caused the TypeError because of NDA reasons.